### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Build Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/a2geek/dns-publisher-release/security/code-scanning/1](https://github.com/a2geek/dns-publisher-release/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/go.yml`, directly under `name` (or before `jobs`).  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing behavior (checkout/build/test) while ensuring `GITHUB_TOKEN` is explicitly restricted. No other imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
